### PR TITLE
Fix: IndentationError: unexpected indent

### DIFF
--- a/custom_components/rpi_power/sensor.py
+++ b/custom_components/rpi_power/sensor.py
@@ -8,7 +8,7 @@ from homeassistant.helpers.entity import Entity
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.sensor import (PLATFORM_SCHEMA)
 
-__version__ = '0.1.4'
+__version__ = '0.1.5'
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/rpi_power/sensor.py
+++ b/custom_components/rpi_power/sensor.py
@@ -42,6 +42,7 @@ class RaspberryChargerSensor(Entity):
         """The update method"""
         _throttled = open(SYSFILE, 'r').read()[:-1]
         _throttled = _throttled[:4]
+        if _throttled == '0':
             self._description = 'Everything is working as intended'
         elif _throttled == '1000':
             self._description = 'Under-voltage was detected, consider getting a uninterruptible power supply for your Raspberry Pi.'


### PR DESCRIPTION
Latest update brakes home assistant start because of syntax error in sensor.py.

```
2019-06-20 12:20:08 ERROR (MainThread) [coap] Exception CancelledError() can not be represented as errno, setting -1.
2019-06-20 12:20:08 ERROR (MainThread) [homeassistant.setup] Error during setup of component notify
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/asyncio/runners.py", line 43, in run
    return loop.run_until_complete(main)
  File "uvloop/loop.pyx", line 1451, in uvloop.loop.Loop.run_until_complete
  File "/usr/src/homeassistant/homeassistant/__main__.py", line 290, in setup_and_run_hass
    log_no_color=args.log_no_color)
  File "/usr/src/homeassistant/homeassistant/bootstrap.py", line 188, in async_from_config_file
    config_dict, hass, enable_log=False, skip_pip=skip_pip)
  File "/usr/src/homeassistant/homeassistant/bootstrap.py", line 92, in async_from_config_dict
    await _async_set_up_integrations(hass, config)
  File "/usr/src/homeassistant/homeassistant/bootstrap.py", line 411, in _async_set_up_integrations
    for domain in domains_to_load
  File "/usr/src/homeassistant/homeassistant/setup.py", line 50, in async_setup_component
    return await task  # type: ignore
  File "/usr/src/homeassistant/homeassistant/setup.py", line 126, in _async_setup_component
    hass, config, integration)
  File "/usr/src/homeassistant/homeassistant/config.py", line 705, in async_process_component_config
    platform = p_integration.get_platform(domain)
  File "/usr/src/homeassistant/homeassistant/loader.py", line 139, in get_platform
    "{}.{}".format(self.pkg_path, platform_name)
  File "/usr/local/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 724, in exec_module
  File "<frozen importlib._bootstrap_external>", line 860, in get_code
  File "<frozen importlib._bootstrap_external>", line 791, in source_to_code
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/config/custom_components/rpi_power/sensor.py", line 45
    self._description = 'Everything is working as intended'
    ^
IndentationError: unexpected indent
```