### PR TITLE
Update according the new naming (Hass.io -> Home Assistant)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,25 +5,25 @@
 [![Contributors][contributors-shield]][contributors]<a href="https://liberapay.com/Toast/donate"><img alt="Donate using Liberapay" align="right" align="top" src="https://liberapay.com/assets/widgets/donate.svg"></a>
 [![Discord][discord-shield]][discord]
 
-A sensor for Home-Assistant that checks your power supply and reports back to your setup
+A sensor for Home Assistant that checks your power supply and reports back to your setup
 this simple sensor reports values from the kernel and if it reports anything else then 0 then there are issues with the power supply.
 
-For more information about Raspberry Pi Power supplies check the following [link](https://github.com/superjamie/lazyweb/wiki/Raspberry-Pi-Power)
+For more information about Raspberry Pi Power supplies check the following [link](https://github.com/superjamie/lazyweb/wiki/Raspberry-Pi-Power).
 
 ## Getting started
 
 ⚠️ This requires kernel 4.14 or higher.
 
-Place the component at this location on your setup: 
+Place the component at this location on your setup:
 
-* Hass.io: `/custom_components/rpi_power/sensor.py`
-* Hassbian / Other: `<config directory>/custom_components/rpi_power/sensor.py`
+* Home Assistant (former Hass.io): `/custom_components/rpi_power/sensor.py`
+* Home Assistant Core / Hassbian / Other: `<config directory>/custom_components/rpi_power/sensor.py`
 
  	\__init__.py and manifest.json needs to be in the same folder
 
-and then restart homeassistant to make sure the component loads.
+and then restart Home Assistant to make sure the component loads.
 
-Here is a list of the current values the component checks for 
+Here is a list of the current values the component checks for:
 
 | Value  | Description |
 | ------------- | ------------- |
@@ -43,7 +43,7 @@ sensor:
   text_state: true
 ```
 
-and then this as an automation that sets off a notification in homeassistant.
+and then this as an automation that sets off a notification in Home Assistant.
 
 ```yaml
 - id: rpi_power_issue
@@ -72,10 +72,11 @@ and then this as an automation that sets off a notification in homeassistant.
 | --- | --- | --- | ---
 | **text_state** | no | `false` | Sets the description as the state if `true`.
 
-Due to how `custom_components` are loaded, it is normal to see a `ModuleNotFoundError` error on first boot after adding this, to resolve it, restart Home-Assistant.
+Due to how `custom_components` are loaded, it is normal to see a `ModuleNotFoundError` error on first boot after adding this, to resolve it, restart Home Assistant.
 
 ## Issues
-Use the bugtracker for your issues if a value is missing please use the following command to get the value
+
+Use the bugtracker for your issues if a value is missing please use the following command to get the value:
 
 ```bash
 cat /sys/devices/platform/soc/soc:firmware/get_throttled


### PR DESCRIPTION
- No longer use Hass.io to avoid confusion
- Remove a couple of trailing whitespaces